### PR TITLE
fix: interpolation for parameters before optional params

### DIFF
--- a/packages/core/src/urls.ts
+++ b/packages/core/src/urls.ts
@@ -88,7 +88,7 @@ export function interpolateUrl (template: string, params: Params): string {
     paramName = snakeCase(paramName)
     value = value
       .replace(new RegExp(escapeRegExp(`(/:${paramName})`), 'g'), `/${paramValue}`)
-      .replace(new RegExp(`:${escapeRegExp(paramName)}(\\/|\\.|$)`, 'g'), `${paramValue}$1`)
+      .replace(new RegExp(`:${escapeRegExp(paramName)}(\\/|\\.|\\(|$)`, 'g'), `${paramValue}$1`)
   })
 
   // Remove any optional path if the parameters were not provided.

--- a/packages/core/test/urls.test.ts
+++ b/packages/core/test/urls.test.ts
@@ -25,6 +25,9 @@ describe('interpolateUrl', () => {
 
     expect(interpolateUrl('(/:locale)/users/:id', { id: '5', loc: '9000' }))
       .toEqual('/users/5')
+
+    expect(interpolateUrl('/users/:id(/:page)', { id: '5' }))
+      .toEqual('/users/5')
   })
 })
 


### PR DESCRIPTION
### Description 📖

This PR applies the patch from #26 to the actual source code. (The patch in the issue only related to the `dist` folder.)

### Background 📜

in the process of adding `js_from_routes` to a project, I noticed a problem where I couldn't generate a path for one of my URLs.

```js
import { definePathHelper } from '@js-from-routes/client'
const get = definePathHelper('get', '/by/:username(/:page)')
console.log(get.path({ username: 'example' }))

// Throws: Uncaught (in promise) TypeError: Missing URL Parameter :username for /by/:username(/:page). Params provided: username
```

I dug into the source code and the problem was that the regex which replaces the parts of the path expects params to be followed by either `/`, `.` or the end of the string.

### The Fix 🔨

In the end, I only had to add another case, where the next character could be a `(`, and everything started working. I also added a test case to make sure it keeps working in the future.