### PR TITLE
fix: obtaining csrf token from response headers

### DIFF
--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -123,7 +123,7 @@ export const Config = {
    */
   withResponse (response: Response) {
     // Extract a CSRF token provided in the headers.
-    const headers: Record<string, any> = response.headers || {}
-    Config.csrfToken = headers['x-csrf-token'] || Config.csrfToken
+    const headers = response.headers || {}
+    Config.csrfToken = headers.get('x-csrf-token') || Config.csrfToken
   },
 }


### PR DESCRIPTION
Calling [] for headers was always returning undefined, never the header desired. This bug is also caught by typescript now that we are no longer coercing the object incorrectly.

### Description 📖

This pull request fixes a bug in withResponse for Fetch

### Background 📜

This was happening because of incorrect type coercion an incorrect expectation of the API for response headers. See: https://developer.mozilla.org/en-US/docs/Web/API/Headers

### The Fix 🔨

Use `get` method to return header value. Remove incorrect type coercion.

### Screenshots 📷
n/a