### PR TITLE
fix: serialize data before sending it to the backend

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.codeActionsOnSave": { "source.fixAll.eslint": true },
+  "[typescript]": {
+    "editor.defaultFormatter": null // disable prettier if present. Let eslint handle it.
+  }
+}

--- a/packages/inertia/src/config.ts
+++ b/packages/inertia/src/config.ts
@@ -1,0 +1,11 @@
+import { snakeCase, deepConvertKeys } from '@js-from-routes/core'
+/**
+ * You may customize these options to configure how requests are sent.
+ */
+export const Config = {
+  /**
+   * The function used to convert the data before sending it to the server.
+   * @default snakeCaseKeys
+   */
+  serializeData: (data: any) => deepConvertKeys(data, snakeCase),
+}

--- a/packages/inertia/src/types.ts
+++ b/packages/inertia/src/types.ts
@@ -21,6 +21,7 @@ export interface FormHelper {
   post: RequestMethod
   put: RequestMethod
   patch: RequestMethod
+  transform: (data: any) => any
 }
 
 /**
@@ -41,6 +42,12 @@ export interface RequestOptions extends VisitOptions {
    * An Inertia.js form to submit in the request.
    */
   form?: FormHelper
+
+  /**
+   * The function used to convert the data before sending it to the server.
+   * @default snakeCaseKeys
+   */
+  serializeData?: (data: any) => any
 }
 
 export type Options = RequestOptions | UrlOptions

--- a/packages/inertia/test/index.test.ts
+++ b/packages/inertia/test/index.test.ts
@@ -1,5 +1,17 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { Inertia } from '@inertiajs/inertia'
 import { definePathHelper, formatUrl } from '../src'
+import { Config } from '../src/config'
+
+vi.mock('@inertiajs/inertia', () => ({
+  Inertia: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
 
 describe('formatUrl', () => {
   it('is exported correctly', () => {
@@ -14,5 +26,67 @@ describe('definePathHelper', () => {
     expect(helper.httpMethod).toEqual('get')
     expect(helper.pathTemplate).toEqual('/videos/:id/download')
     expect(helper.path({ i: 2, id: 5 })).toEqual('/videos/5/download')
+  })
+})
+
+describe('request', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('serializes data before sending the request', () => {
+    it('POST', () => {
+      const helper = definePathHelper('post', '/videos/:id/download')
+
+      helper({ data: { id: 5, camelKey: 'test' } })
+
+      expect(Inertia.post).toHaveBeenCalledWith(
+        '/videos/5/download',
+        { camel_key: 'test', id: 5 },
+        { data: { camelKey: 'test', id: 5 } },
+      )
+    })
+
+    it('DELETE', () => {
+      const helper = definePathHelper('delete', '/videos/:id/download')
+
+      helper({ params: { id: 5 }, data: { camelKey: 'test' } })
+
+      expect(Inertia.delete).toHaveBeenCalledWith('/videos/5/download', {
+        data: { camel_key: 'test' },
+        params: { id: 5 },
+      })
+    })
+
+    describe('as a form helper', () => {
+      it('snake cases keys', () => {
+        const helper = definePathHelper('post', '/videos/:id/download')
+        const form = {
+          transform: vi.fn(),
+          post: vi.fn(),
+          data: { camelKey: 'test' },
+        }
+
+        helper({ params: { id: 5 }, form })
+
+        expect(form.post).toHaveBeenCalledWith('/videos/5/download', {})
+        expect(form.transform).toHaveBeenCalledWith(Config.serializeData)
+      })
+
+      it('allows to pass in a custom serializer', () => {
+        const helper = definePathHelper('post', '/videos/:id/download')
+        const form = {
+          transform: vi.fn(),
+          post: vi.fn(),
+          data: { camelKey: 'test' },
+        }
+        const serializeData = () => ({ camel_key: 'test' })
+
+        helper({ params: { id: 5 }, form, serializeData })
+
+        expect(form.post).toHaveBeenCalledWith('/videos/5/download', {})
+        expect(form.transform).toHaveBeenCalledWith(serializeData)
+      })
+    })
   })
 })


### PR DESCRIPTION
### Description 📖

This pull request fixes the inertia client so that it serializes data, using `deepConvertKeys(data, snakeCase)` before sending it to the backend. This is the [same behavior](https://github.com/ElMassimo/js_from_routes/blob/main/packages/client/src/api.ts#L64) as the standard js_from_routes client.

### Background 📜

This was happening because the data serialization / deserialization is completely missing for the inertia client. This causes a mismatch between the rails backend and the frontend as when submitting data to the rails app, it's expecting snake_case params but the inertia client is sending camelCase params.

![image](https://github.com/ElMassimo/js_from_routes/assets/3678598/cb1d12b5-fbc3-4412-98b2-e8c7c9039154)
_Image: the expected param is `tax_id` in the backend, but the frontend is sending `taxId`_


### The Fix 🔨

By using the same convention as for the standard client, in which we have a Config object that takes a `serializeData` function that gets called before sending data to the backend, we can `deepConvertKeys` with `snakeCase`  in order to send the right key casing to the backend.

### Future Work 🔮 

It could be also good to implement the rest of the configuration options (e.g `deserializeData`, `baseUrl`, etc). I didn't implement the `deserializeData` because I'm using [types_from_serializers](https://github.com/ElMassimo/types_from_serializers) which already sends the data in `camelCase` format to the frontend. So no need for deserialization.
