### PR TITLE
feat: allow customizing the namespace for path helpers

### DIFF
--- a/js_from_routes/lib/js_from_routes/generator.rb
+++ b/js_from_routes/lib/js_from_routes/generator.rb
@@ -15,8 +15,13 @@ module JsFromRoutes
     def initialize(controller, routes, config)
       @controller, @config = controller, config
       @routes = routes
-        .uniq { |route| route.requirements.fetch(:action) }
-        .map { |route| Route.new(route, config.helper_mappings) }
+        .reject { |route| route.requirements[:action] == "update" && route.verb == "PUT" }
+        .group_by { |route| route.requirements.fetch(:action) }
+        .flat_map { |action, routes|
+          routes.each_with_index.map { |route, index|
+            Route.new(route, mappings: config.helper_mappings, index:, controller:)
+          }
+        }
     end
 
     # Public: Used to check whether the file should be generated again, changes
@@ -53,8 +58,8 @@ module JsFromRoutes
 
   # Internal: A presenter for an individual Rails action.
   class Route
-    def initialize(route, mappings = {})
-      @route, @mappings = route, mappings
+    def initialize(route, mappings:, controller:, index: 0)
+      @route, @mappings, @controller, @index = route, mappings, controller, index
     end
 
     # Public: The `export` setting specified for the action.
@@ -64,7 +69,7 @@ module JsFromRoutes
 
     # Public: The HTTP verb for the action. Example: 'patch'
     def verb
-      @route.verb.downcase
+      @route.verb.split("|").last.downcase
     end
 
     # Public: The path for the action. Example: '/users/:id/edit'
@@ -74,8 +79,12 @@ module JsFromRoutes
 
     # Public: The name of the JS helper for the action. Example: 'destroyAll'
     def helper
-      action = @route.requirements.fetch(:action).camelize(:lower)
-      @mappings.fetch(action, action)
+      action = @route.requirements.fetch(:action)
+      if @index > 0
+        action = @route.name&.sub(@controller.tr(":/", "_"), "") || "#{action}#{verb.titleize}"
+      end
+      helper = action.camelize(:lower)
+      @mappings.fetch(helper, helper)
     end
 
     # Internal: Useful as a cache key for the route, and for debugging purposes.
@@ -164,7 +173,8 @@ module JsFromRoutes
 
     def generate_files(exported_routes)
       template = Template.new(config.template_path)
-      generate_file_for_all exported_routes.map { |controller, routes|
+      generate_file_for_all exported_routes.filter_map { |controller, routes|
+        next unless controller
         ControllerRoutes.new(controller, routes, config).tap do |routes|
           template.write_if_changed routes
         end
@@ -188,13 +198,17 @@ module JsFromRoutes
       )
     end
 
+    def namespace_for_route(route)
+      if (export = route.defaults[:export]).is_a?(Hash)
+        export[:namespace]
+      end || route.requirements[:controller]
+    end
+
     # Internal: Returns exported routes grouped by controller name.
     def exported_routes_by_controller(routes)
-      routes.select { |route|
-        config.export_if.call(route) && route.requirements[:controller]
-      }.group_by { |route|
-        route.requirements.fetch(:controller)
-      }
+      routes
+        .select { |route| config.export_if.call(route) }
+        .group_by { |route| namespace_for_route(route)&.to_s }
     end
   end
 end


### PR DESCRIPTION
### Description 📖

This pull request is an attempt to address some of the shortcomings of grouping routes by controllers in apps that have more complex routing:

- #42
- #48

It adds support for a `namespace` option in `export`:

```ruby
resources :video_clips, export: {namespace: :videos} do
  get :download, on: :member
end
```

which would then generate a `VideosApi.ts` file instead of `VideoClipsApi.ts`.

As a result it's now possible to create custom groupings of path helpers, providing a flexible and intuitive escape hatch for routes that have complex nesting or where the usage in the frontend benefits from a different grouping.

### Background 📜 

In setups [like the following](https://github.com/ElMassimo/js_from_routes/issues/42), users can now define a separate file for helpers:

```ruby
resources :sections, path: "s", param: :slug do
  resources :discussions
end

resources :custom_sections, path: "cs", param: :slug, export: {namespace: "custom_section_discussions"} do
  resources :discussions
end
```
which will generate another file (`CustomSectionDiscussionsApi.ts`), containing the second set of paths.

In addition, this pull request also prevents different routes that target the same action from being omitted, in which case it will try to disambiguate additional routes by using their fully qualified name or verb.

FYI @reinvanimschoot @Shaglock