### PR TITLE
chore: remove openstruct references

### DIFF
--- a/js_from_routes/lib/js_from_routes/generator.rb
+++ b/js_from_routes/lib/js_from_routes/generator.rb
@@ -187,18 +187,15 @@ module JsFromRoutes
       preferred_extension = File.extname(config.file_suffix)
       index_file = (config.all_helpers_file == true) ? "index#{preferred_extension}" : config.all_helpers_file
 
-      template_all_path_config = TemplateConfig.new(
+      Template.new(config.template_all_path).write_if_changed TemplateConfig.new(
         cache_key: routes.map(&:import_filename).join + File.read(config.template_all_path),
         filename: config.output_folder.join("all#{preferred_extension}"),
-        helpers: routes
+        helpers: routes,
       )
-      template_index_path_config = TemplateConfig.new(
+      Template.new(config.template_index_path).write_if_changed TemplateConfig.new(
         cache_key: File.read(config.template_index_path),
         filename: config.output_folder.join(index_file)
       )
-
-      Template.new(config.template_all_path).write_if_changed template_all_path_config
-      Template.new(config.template_index_path).write_if_changed template_index_path_config
     end
 
     # Internal: Returns exported routes grouped by controller name.

--- a/js_from_routes/lib/js_from_routes/generator.rb
+++ b/js_from_routes/lib/js_from_routes/generator.rb
@@ -194,7 +194,7 @@ module JsFromRoutes
       )
       Template.new(config.template_index_path).write_if_changed TemplateConfig.new(
         cache_key: File.read(config.template_index_path),
-        filename: config.output_folder.join(index_file)
+        filename: config.output_folder.join(index_file),
       )
     end
 

--- a/js_from_routes/lib/js_from_routes/generator.rb
+++ b/js_from_routes/lib/js_from_routes/generator.rb
@@ -145,6 +145,16 @@ module JsFromRoutes
     end
   end
 
+  class TemplateConfig
+    attr_reader :cache_key, :filename, :helpers
+
+    def initialize(cache_key:, filename:, helpers: nil)
+      @cache_key = cache_key
+      @filename = filename
+      @helpers = helpers
+    end
+  end
+
   class << self
     # Public: Configuration of the code generator.
     def config
@@ -177,15 +187,18 @@ module JsFromRoutes
       preferred_extension = File.extname(config.file_suffix)
       index_file = (config.all_helpers_file == true) ? "index#{preferred_extension}" : config.all_helpers_file
 
-      Template.new(config.template_all_path).write_if_changed OpenStruct.new(
+      template_all_path_config = TemplateConfig.new(
         cache_key: routes.map(&:import_filename).join + File.read(config.template_all_path),
         filename: config.output_folder.join("all#{preferred_extension}"),
-        helpers: routes,
+        helpers: routes
       )
-      Template.new(config.template_index_path).write_if_changed OpenStruct.new(
+      template_index_path_config = TemplateConfig.new(
         cache_key: File.read(config.template_index_path),
-        filename: config.output_folder.join(index_file),
+        filename: config.output_folder.join(index_file)
       )
+
+      Template.new(config.template_all_path).write_if_changed template_all_path_config
+      Template.new(config.template_index_path).write_if_changed template_index_path_config
     end
 
     # Internal: Returns exported routes grouped by controller name.


### PR DESCRIPTION
### Description 📖

Somehow missed this OpenStruct usage, since the warning/error was gone after the first PR. Maybe this will lead to warnings/errors in future so I decided to refactor this part as well. 

### Background 📜

This was happening because of ruby 3.3.5 upgrade and openstruct warning. See https://github.com/ElMassimo/js_from_routes/issues/47#issuecomment-2374877576

### The Fix 🔨

Added TemplateConfig class similar to the previous OpenStruct usage 

### Screenshots 📷
