### PR TITLE
Pathname.blank? returns true for empty directories in some environments

### DIFF
--- a/js_from_routes/lib/js_from_routes/generator.rb
+++ b/js_from_routes/lib/js_from_routes/generator.rb
@@ -174,7 +174,7 @@ module JsFromRoutes
 
     # Public: Generates code for the specified routes with { export: true }.
     def generate!(app_or_routes = Rails.application)
-      raise ArgumentError, "A Rails app must be defined, or you must specify a custom `output_folder`" if config.output_folder.blank?
+      raise ArgumentError, "A Rails app must be defined, or you must specify a custom `output_folder`" if config.output_folder.to_s.blank?
       rails_routes = app_or_routes.is_a?(::Rails::Engine) ? app_or_routes.routes.routes : app_or_routes
       generate_files exported_routes_by_controller(rails_routes)
     end


### PR DESCRIPTION
### Description 📖

This fixes a weird bug I was seeing in a CI environment, where a `Pathname` pointing to an empty directory responds `true` to `blank?`

### Background 📜

When building a step in our CI, to see if any outdated route files needed to be removed. I was unable to get the rake task to fire off after `rm -Rf`'ing the existing routes folder. This behavior did not occur locally (OSX), and I ended up down quite the rabbit hole.

Temp fix for CI was to `touch output_dir/all.js` 

### The Fix 🔨

By checking the output directory as a `string` rather than a `Pathname`, we can see if the configured value is present (which I believe is the intent here)