### PR TITLE
feat: add support for custom helper names via js_helper_name parameter

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -63,6 +63,38 @@ end
 
 It will cascade to any nested action or resource, but you can [opt out][export false] with `export: false`.
 
+### Customize helper names
+
+By default, helper names are automatically generated from the controller action name (e.g., `index` becomes `index`, `show` becomes `show`). You can customize the generated helper name for any route using `js_helper_name`:
+
+```ruby {2}
+Rails.application.routes.draw do
+  resources :admin_update_logs, only: [:index], export: true, js_helper_name: "filteredIndex"
+
+  # For specific actions in resources:
+  resources :video_clips, only: [:show], export: true do
+    get :download, on: :member, js_helper_name: "downloadVideo"
+  end
+end
+```
+
+This generates helpers with your custom names:
+
+```js
+// app/frontend/api/AdminUpdateLogsApi.ts
+export default {
+  filteredIndex: definePathHelper('get', '/admin_update_logs'),
+}
+
+// app/frontend/api/VideoClipsApi.ts
+export default {
+  show: definePathHelper('get', '/video_clips/:id'),
+  downloadVideo: definePathHelper('get', '/video_clips/:id/download'),
+}
+```
+
+This is particularly useful for routes that have generic action names but specific purposes, or when you want more descriptive helper names in your JavaScript code.
+
 ### Refresh the page
 
 Rails' reloader will detect the changes, and path helpers will be [generated][codegen] for the exported actions.

--- a/js_from_routes/lib/js_from_routes/generator.rb
+++ b/js_from_routes/lib/js_from_routes/generator.rb
@@ -79,6 +79,9 @@ module JsFromRoutes
 
     # Public: The name of the JS helper for the action. Example: 'destroyAll'
     def helper
+      js_helper_name = @route.defaults[:js_helper_name]
+      return js_helper_name if js_helper_name.present?
+
       action = @route.requirements.fetch(:action)
       if @index > 0
         action = @route.name&.sub(@controller.tr(":/", "_"), "") || "#{action}#{verb.titleize}"


### PR DESCRIPTION
### Description 📖

This pull request adds support for customizing generated helper names in routes using a new `js_helper_name` parameter. This allows developers to override the automatic helper name generation and maintain consistent naming patterns across polymorphic controllers and complex route structures.

### Background 📜

This was happening because the automatic helper name generation creates inconsistent names for polymorphic controllers. For example, with an `admin_update_logs` controller that handles both receipts and referrals, the generated helpers were:

```js
export default {
  index: /* #__PURE__ */ definePathHelper('get', '/admin/v2/receipts/:receipt_id/admin_update_logs'),
  adminV2ReferralAdminUpdateLogs: /* #__PURE__ */ definePathHelper('get', '/admin/v2/referrals/:referral_id/admin_update_logs'),
}
```

The first route gets a generic `index` name while the second gets a verbose auto-generated name, creating inconsistency in the JavaScript API and making it harder to maintain a predictable naming pattern across related routes.

### The Fix 🔨

By changing the generator to check for a `js_helper_name` parameter in route defaults before falling back to automatic name generation:

```ruby
def helper
  js_helper_name = @route.defaults[:js_helper_name]
  return js_helper_name if js_helper_name.present?

  # existing automatic generation logic...
end
```

And allowing developers to specify custom names in their routes:

```ruby
Rails.application.routes.draw do
  namespace :admin do
    namespace :v2 do
      resources :receipts do
        resources :admin_update_logs, only: [:index], js_helper_name: "adminV2ReceiptAdminUpdateLogs"
      end
      
      resources :referrals do
        resources :admin_update_logs, only: [:index], js_helper_name: "adminV2ReferralAdminUpdateLogs"
      end
    end
  end
end
```

This now generates consistent, descriptive helper names:

```js
export default {
  adminV2ReceiptAdminUpdateLogs: definePathHelper('get', '/admin/v2/receipts/:receipt_id/admin_update_logs'),
  adminV2ReferralAdminUpdateLogs: definePathHelper('get', '/admin/v2/referrals/:referral_id/admin_update_logs'),
}
```

The fix maintains backward compatibility while giving developers full control over helper naming for complex route structures and polymorphic controllers.