### PR TITLE
feat: support multiple generator instances for sub-app routing

### DIFF
--- a/js_from_routes/lib/js_from_routes/generator.rb
+++ b/js_from_routes/lib/js_from_routes/generator.rb
@@ -164,19 +164,32 @@ module JsFromRoutes
     end
   end
 
-  class << self
-    # Public: Configuration of the code generator.
-    def config
-      @config ||= Configuration.new(::Rails.root || Pathname.new(Dir.pwd))
-      yield(@config) if block_given?
-      @config
+  # Public: A generator instance with its own configuration. Allows generating
+  # routes separately for different sub-apps in a Rails monolith.
+  #
+  # Example:
+  #   JsFromRoutes.instance(:admin) do |config|
+  #     config.output_folder = Rails.root.join("app/javascript/admin/api")
+  #     config.export_if = ->(route) { route.defaults[:export] == :admin }
+  #   end
+  #
+  #   JsFromRoutes.instance(:public) do |config|
+  #     config.output_folder = Rails.root.join("app/javascript/public/api")
+  #     config.export_if = ->(route) { route.defaults[:export] == :public }
+  #   end
+  class Instance
+    attr_reader :name, :config
+
+    def initialize(name, config)
+      @name = name
+      @config = config
     end
 
     # Public: Generates code for the specified routes with { export: true }.
     def generate!(app_or_routes = Rails.application)
       raise ArgumentError, "A Rails app must be defined, or you must specify a custom `output_folder`" if config.output_folder.to_s.blank?
       rails_routes = app_or_routes.is_a?(::Rails::Engine) ? app_or_routes.routes.routes : app_or_routes
-      generate_files exported_routes_by_controller(rails_routes)
+      generate_files(exported_routes_by_controller(rails_routes))
     end
 
     private
@@ -219,6 +232,47 @@ module JsFromRoutes
       routes
         .select { |route| config.export_if.call(route) }
         .group_by { |route| namespace_for_route(route)&.to_s }
+    end
+  end
+
+  class << self
+    # Public: Configuration of the code generator.
+    def config
+      @config ||= Configuration.new(::Rails.root || Pathname.new(Dir.pwd))
+      yield(@config) if block_given?
+      @config
+    end
+
+    # Public: Defines a named generator instance with its own configuration.
+    # Each instance can target different routes and output to different folders.
+    #
+    # Example:
+    #   JsFromRoutes.instance(:admin) do |config|
+    #     config.output_folder = Rails.root.join("app/javascript/admin/api")
+    #     config.export_if = ->(route) { route.defaults[:export] == :admin }
+    #   end
+    def instance(name, &block)
+      root = ::Rails.root || Pathname.new(Dir.pwd)
+      new_config = Configuration.new(root)
+      yield(new_config) if block_given?
+      instances[name] = Instance.new(name, new_config)
+    end
+
+    # Public: Returns all registered named instances.
+    def instances
+      @instances ||= {}
+    end
+
+    # Public: Generates code for the specified routes with { export: true }.
+    # When named instances are defined, generates for each instance.
+    # Otherwise, falls back to the default global config.
+    def generate!(app_or_routes = Rails.application)
+      if instances.any?
+        instances.each_value { |inst| inst.generate!(app_or_routes) }
+      else
+        raise ArgumentError, "A Rails app must be defined, or you must specify a custom `output_folder`" if config.output_folder.to_s.blank?
+        Instance.new(:default, config).generate!(app_or_routes)
+      end
     end
   end
 end

--- a/js_from_routes/lib/js_from_routes/generator.rb
+++ b/js_from_routes/lib/js_from_routes/generator.rb
@@ -168,12 +168,12 @@ module JsFromRoutes
   # routes separately for different sub-apps in a Rails monolith.
   #
   # Example:
-  #   JsFromRoutes.instance(:admin) do |config|
+  #   JsFromRoutes.config(:admin) do |config|
   #     config.output_folder = Rails.root.join("app/javascript/admin/api")
   #     config.export_if = ->(route) { route.defaults[:export] == :admin }
   #   end
   #
-  #   JsFromRoutes.instance(:public) do |config|
+  #   JsFromRoutes.config(:public) do |config|
   #     config.output_folder = Rails.root.join("app/javascript/public/api")
   #     config.export_if = ->(route) { route.defaults[:export] == :public }
   #   end
@@ -237,25 +237,29 @@ module JsFromRoutes
 
   class << self
     # Public: Configuration of the code generator.
-    def config
-      @config ||= Configuration.new(::Rails.root || Pathname.new(Dir.pwd))
-      yield(@config) if block_given?
-      @config
-    end
-
-    # Public: Defines a named generator instance with its own configuration.
-    # Each instance can target different routes and output to different folders.
     #
-    # Example:
-    #   JsFromRoutes.instance(:admin) do |config|
+    # Without a name, returns/yields the default global configuration:
+    #   JsFromRoutes.config do |config|
+    #     config.file_suffix = "Api.ts"
+    #   end
+    #
+    # With a name, defines a named generator instance with its own configuration,
+    # allowing separate route generation for different sub-apps:
+    #   JsFromRoutes.config(:admin) do |config|
     #     config.output_folder = Rails.root.join("app/javascript/admin/api")
     #     config.export_if = ->(route) { route.defaults[:export] == :admin }
     #   end
-    def instance(name, &block)
-      root = ::Rails.root || Pathname.new(Dir.pwd)
-      new_config = Configuration.new(root)
-      yield(new_config) if block_given?
-      instances[name] = Instance.new(name, new_config)
+    def config(name = nil)
+      if name
+        root = ::Rails.root || Pathname.new(Dir.pwd)
+        new_config = Configuration.new(root)
+        yield(new_config) if block_given?
+        instances[name] = Instance.new(name, new_config)
+      else
+        @config ||= Configuration.new(::Rails.root || Pathname.new(Dir.pwd))
+        yield(@config) if block_given?
+        @config
+      end
     end
 
     # Public: Returns all registered named instances.

--- a/js_from_routes/lib/js_from_routes/generator.rb
+++ b/js_from_routes/lib/js_from_routes/generator.rb
@@ -257,7 +257,10 @@ module JsFromRoutes
         instances[name] = Instance.new(name, new_config)
       else
         @config ||= Configuration.new(::Rails.root || Pathname.new(Dir.pwd))
-        yield(@config) if block_given?
+        if block_given?
+          @config_customized = true
+          yield(@config)
+        end
         @config
       end
     end
@@ -268,15 +271,15 @@ module JsFromRoutes
     end
 
     # Public: Generates code for the specified routes with { export: true }.
-    # When named instances are defined, generates for each instance.
-    # Otherwise, falls back to the default global config.
+    #
+    # Runs every named instance, plus the default global config whenever it was
+    # explicitly configured (or when no named instances exist at all). This keeps
+    # mixed usage working: adding a named instance never silently disables the
+    # global config that an existing app already relies on.
     def generate!(app_or_routes = Rails.application)
-      if instances.any?
-        instances.each_value { |inst| inst.generate!(app_or_routes) }
-      else
-        raise ArgumentError, "A Rails app must be defined, or you must specify a custom `output_folder`" if config.output_folder.to_s.blank?
-        Instance.new(:default, config).generate!(app_or_routes)
-      end
+      runnable = instances.values
+      runnable.unshift(Instance.new(:default, config)) if @config_customized || runnable.empty?
+      runnable.each { |inst| inst.generate!(app_or_routes) }
     end
   end
 end

--- a/spec/js_from_routes/js_from_routes_spec.rb
+++ b/spec/js_from_routes/js_from_routes_spec.rb
@@ -120,11 +120,8 @@ describe JsFromRoutes do
 
     before do
       [admin_output_dir, public_output_dir].each do |dir|
-        begin
-          FileUtils.remove_dir(dir)
-        rescue
-          nil
-        end
+        expect(dir.to_s).to start_with(output_dir.to_s)
+        FileUtils.rm_rf(dir)
       end
 
       JsFromRoutes.config(:admin) do |config|
@@ -145,13 +142,13 @@ describe JsFromRoutes do
     it "generates only matching route subsets for each instance" do
       JsFromRoutes.generate!
 
-      expect(file_for(admin_output_dir, "Settings/UserPreferences").exist?).to eq true
-      expect(file_for(admin_output_dir, "Comments").exist?).to eq false
-      expect(file_for(admin_output_dir, "VideoClips").exist?).to eq false
+      expect(file_for(admin_output_dir, "Settings/UserPreferences").exist?).to be true
+      expect(file_for(admin_output_dir, "Comments").exist?).to be false
+      expect(file_for(admin_output_dir, "VideoClips").exist?).to be false
 
-      expect(file_for(public_output_dir, "Settings/UserPreferences").exist?).to eq false
-      expect(file_for(public_output_dir, "Comments").exist?).to eq true
-      expect(file_for(public_output_dir, "VideoClips").exist?).to eq true
+      expect(file_for(public_output_dir, "Settings/UserPreferences").exist?).to be false
+      expect(file_for(public_output_dir, "Comments").exist?).to be true
+      expect(file_for(public_output_dir, "VideoClips").exist?).to be true
     end
   end
 

--- a/spec/js_from_routes/js_from_routes_spec.rb
+++ b/spec/js_from_routes/js_from_routes_spec.rb
@@ -50,6 +50,10 @@ describe JsFromRoutes do
     end
   end
 
+  after do
+    JsFromRoutes.instances.clear
+  end
+
   # NOTE: We do a manual snapshot test for now, more tests coming in the future.
   it "should generate the files as expected" do
     expect_templates.to be_rendered.exactly(3).times.and_call_original
@@ -107,6 +111,47 @@ describe JsFromRoutes do
       # Should not trigger another render.
       expect_templates.not_to be_rendered
       JsFromRoutes.generate!
+    end
+  end
+
+  context "with multiple named instances" do
+    let(:admin_output_dir) { output_dir.join("admin") }
+    let(:public_output_dir) { output_dir.join("public") }
+
+    before do
+      [admin_output_dir, public_output_dir].each do |dir|
+        begin
+          FileUtils.remove_dir(dir)
+        rescue
+          nil
+        end
+      end
+
+      JsFromRoutes.config(:admin) do |config|
+        config.output_folder = admin_output_dir
+        config.all_helpers_file = false
+        config.file_suffix = "Api.ts"
+        config.export_if = ->(route) { route.defaults[:export] == true && route.requirements[:controller]&.start_with?("settings/") }
+      end
+
+      JsFromRoutes.config(:public) do |config|
+        config.output_folder = public_output_dir
+        config.all_helpers_file = false
+        config.file_suffix = "Api.ts"
+        config.export_if = ->(route) { route.defaults[:export] == true && !route.requirements[:controller]&.start_with?("settings/") }
+      end
+    end
+
+    it "generates only matching route subsets for each instance" do
+      JsFromRoutes.generate!
+
+      expect(file_for(admin_output_dir, "Settings/UserPreferences").exist?).to eq true
+      expect(file_for(admin_output_dir, "Comments").exist?).to eq false
+      expect(file_for(admin_output_dir, "VideoClips").exist?).to eq false
+
+      expect(file_for(public_output_dir, "Settings/UserPreferences").exist?).to eq false
+      expect(file_for(public_output_dir, "Comments").exist?).to eq true
+      expect(file_for(public_output_dir, "VideoClips").exist?).to eq true
     end
   end
 

--- a/spec/js_from_routes/js_from_routes_spec.rb
+++ b/spec/js_from_routes/js_from_routes_spec.rb
@@ -150,6 +150,48 @@ describe JsFromRoutes do
       expect(file_for(public_output_dir, "Comments").exist?).to be true
       expect(file_for(public_output_dir, "VideoClips").exist?).to be true
     end
+
+    it "still generates the explicitly configured global config alongside named instances" do
+      JsFromRoutes.generate!
+
+      # Registering named instances must not silently disable a global config
+      # the app already relies on: its output is still generated to output_dir.
+      controllers_with_exported_routes.each do |file_name|
+        expect(output_file_for(file_name).exist?).to be true
+      end
+    end
+  end
+
+  context "with only named instances and an untouched global config" do
+    let(:only_output_dir) { output_dir.join("only") }
+
+    before do
+      expect(only_output_dir.to_s).to start_with(output_dir.to_s)
+      FileUtils.rm_rf(only_output_dir)
+
+      JsFromRoutes.config(:only) do |config|
+        config.output_folder = only_output_dir
+        config.all_helpers_file = false
+        config.file_suffix = "Api.ts"
+        config.export_if = ->(route) { route.defaults[:export] == true }
+      end
+    end
+
+    it "does not generate the default global config when it was never explicitly configured" do
+      # The shared setup customizes the global config, so simulate an app that
+      # only ever registered named instances by resetting that flag.
+      JsFromRoutes.instance_variable_set(:@config_customized, false)
+
+      JsFromRoutes.generate!
+
+      # The named instance generates its own output...
+      expect(file_for(only_output_dir, "Comments").exist?).to be true
+
+      # ...but no stray default output is written to the global output_folder.
+      controllers_with_exported_routes.each do |file_name|
+        expect(output_file_for(file_name).exist?).to be false
+      end
+    end
   end
 
   it "should have a rake task available" do


### PR DESCRIPTION
Extract generation logic into JsFromRoutes::Instance class, allowing
multiple independently configured generators. Each instance can target
different routes and output to separate folders, enabling monolith
sub-apps (admin, public, etc.) to have isolated route helpers.

```ruby
  JsFromRoutes.config(:admin) do |config|
    config.output_folder = Rails.root.join("app/javascript/admin/api")
    config.export_if = ->(route) { route.defaults[:export] == :admin }
  end
```

Fully backward compatible - without named instances, the existing
global config behavior is preserved.

https://claude.ai/code/session_01XeS58bhuqTEhmxvmWXxZzi